### PR TITLE
添加模型DRACO解压库文件路径

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -29,7 +29,8 @@ export default {
       plugins: [RemoveGlobalNamePlugin()],
       globals: {
         three: 'THREE',
-        'three/examples/jsm/loaders/GLTFLoader.js': 'THREE'
+        'three/examples/jsm/loaders/GLTFLoader.js': 'THREE',
+        'three/examples/jsm/loaders/DRACOLoader.js': 'THREE'
       }
       //当入口文件有export时，'umd'格式必须指定name
       //这样，在通过<script>标签引入时，才能通过name访问到export的内容。

--- a/src/packages/gltf/index.ts
+++ b/src/packages/gltf/index.ts
@@ -23,9 +23,9 @@ export interface GltfOptions {
 }
 
 class ThreeGltf extends BaseEvent{
-  object: any // 加载模型后的Object3D对象
-  animations: any // 模型的动画
-  layer: any // threejs的图层对象
+  object: any; // 加载模型后的Object3D对象
+  animations: any; // 模型的动画
+  layer: any; // threejs的图层对象
   linerAnimationFrame = -1; //gltf动画
 
   constructor(layer: any, options: GltfOptions) {
@@ -43,16 +43,16 @@ class ThreeGltf extends BaseEvent{
       scale: 1,
       angle: 0
     }
-    options = Object.assign({}, defaultOptions, options)
+    options = Object.assign({}, defaultOptions, options);
     this.init(options);
   }
 
   init(options: GltfOptions) {
     const loader = new GLTFLoader(); // 读取模型
     if (options.draco){
-      const dracoLoader = new DRACOLoader()
-      dracoLoader.setDecoderPath(options.draco)
-      loader.setDRACOLoader(dracoLoader)
+      const dracoLoader = new DRACOLoader();
+      dracoLoader.setDecoderPath(options.draco);
+      loader.setDRACOLoader(dracoLoader);
     }
     loader.load(options.url, (gltf) => {
       const object = gltf.scene;
@@ -178,7 +178,7 @@ class ThreeGltf extends BaseEvent{
 
   remove(){
     if (this.object) {
-      this.layer.remove(this.object)
+      this.layer.remove(this.object);
     }
   }
 

--- a/src/packages/gltf/index.ts
+++ b/src/packages/gltf/index.ts
@@ -1,5 +1,5 @@
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
-import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader';
+import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader.js';
 import { AnimationMixer, Clock} from 'three';
 import BaseEvent from '../event'
 import {clearGroup} from '../../utils/threeUtil';

--- a/src/packages/gltf/index.ts
+++ b/src/packages/gltf/index.ts
@@ -1,7 +1,7 @@
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader.js';
 import { AnimationMixer, Clock} from 'three';
-import BaseEvent from '../event'
+import BaseEvent from '../event';
 import {clearGroup} from '../../utils/threeUtil';
 import type {AnimationClip, Group} from 'three';
 

--- a/src/packages/gltf/index.ts
+++ b/src/packages/gltf/index.ts
@@ -1,4 +1,5 @@
-import {GLTFLoader} from 'three/examples/jsm/loaders/GLTFLoader.js';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader';
 import { AnimationMixer, Clock} from 'three';
 import BaseEvent from '../event'
 import {clearGroup} from '../../utils/threeUtil';
@@ -17,6 +18,7 @@ export interface GltfOptions {
   rotation: Vec // 模型旋转角度
   scale: number | Vec  //模型缩放级别，可以整体缩放和按X Y Z缩放
   angle: number //  模型旋转角度
+  draco: string // 模型DRACO解压库文件路径
   onLoaded: (gltf: Group, animations:  AnimationClip[]) => void // gltf加载并且处理完成后回调
 }
 
@@ -47,6 +49,11 @@ class ThreeGltf extends BaseEvent{
 
   init(options: GltfOptions) {
     const loader = new GLTFLoader(); // 读取模型
+    if (options.draco){
+      const dracoLoader = new DRACOLoader()
+      dracoLoader.setDecoderPath(options.draco)
+      loader.setDRACOLoader(dracoLoader)
+    }
     loader.load(options.url, (gltf) => {
       const object = gltf.scene;
       const animations = gltf.animations;


### PR DESCRIPTION
将three中的draco_decoder.js等相关文件拷贝到项目中，配置路径变量<el-amap-three-gltf  :draco="dracoPath" />