### PR TITLE
fix: package.json 补全types声明

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "exports": {
     ".": {
       "require": "./dist/index.cjs",
-      "import": "./dist/index.mjs"
+      "import": "./dist/index.mjs",
+      "types": "./dist/index.d.ts"
     },
     "./*": "./*"
   },


### PR DESCRIPTION
给 package.json 添加一个 types 声明的引用, 缺少这个引用将导致ide无法正确识别ts的类型文件